### PR TITLE
Fix SDL2 includes in OSX

### DIFF
--- a/common/CameraEngine.h
+++ b/common/CameraEngine.h
@@ -24,7 +24,11 @@
 #include <limits.h>
 #include "tinyxml.h"
 #include <math.h>
+#ifdef __APPLE__
+#include <SDL2/SDL.h>
+#else
 #include <SDL.h>
+#endif
 #include "FontTool.h"
 
 #ifdef __APPLE__

--- a/common/FontTool.h
+++ b/common/FontTool.h
@@ -19,7 +19,11 @@
 #ifndef FONTTOOL_H
 #define FONTTOOL_H
 
+#ifdef __APPLE__
+#include <SDL2/SDL.h>
+#else
 #include <SDL.h>
+#endif
 #include "Resources.h"
 #include "SFont.h"
 

--- a/common/FrameProcessor.h
+++ b/common/FrameProcessor.h
@@ -19,7 +19,11 @@
 #ifndef FRAMEPROCESSOR_H
 #define FRAMEPROCESSOR_H
 
+#ifdef __APPLE__
+#include <SDL2/SDL.h>
+#else
 #include <SDL.h>
+#endif
 #include <stdio.h>
 #include <string>
 #include <vector>

--- a/common/FrameThresholder.cpp
+++ b/common/FrameThresholder.cpp
@@ -18,8 +18,13 @@
 */
 
 #include "FrameThresholder.h"
+#ifdef __APPLE__
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_thread.h>
+#else
 #include <SDL.h>
 #include <SDL_thread.h>
+#endif
 
 typedef struct threshold_data{
     TiledBernsenThresholder *thresholder;

--- a/common/Main.cpp
+++ b/common/Main.cpp
@@ -19,7 +19,11 @@
 
 #include <Main.h>
 #include <string.h>
+#ifdef __APPLE__
+#include <SDL2/SDL.h>
+#else
 #include "SDL.h"
+#endif
 #include "SDLinterface.h"
 #include "FrameEqualizer.h"
 #include "FrameThresholder.h"

--- a/common/Resources.h
+++ b/common/Resources.h
@@ -22,7 +22,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#ifdef __APPLE__
+#include <SDL2/SDL.h>
+#else
 #include <SDL.h>
+#endif
 extern unsigned char icon[3126];
 extern unsigned char mask[1024];
 extern unsigned char camera[3910];

--- a/common/SDLinterface.h
+++ b/common/SDLinterface.h
@@ -34,8 +34,13 @@
 
 #include <sys/stat.h>
 
+#ifdef __APPLE__
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_thread.h>
+#else
 #include <SDL.h>
 #include <SDL_thread.h>
+#endif
 #include <time.h>
 
 #define WIDTH 640

--- a/common/SFont.c
+++ b/common/SFont.c
@@ -25,7 +25,11 @@
     karlb@gmx.net
 */
 
+#ifdef __APPLE__
+#include <SDL2/SDL.h>
+#else
 #include <SDL.h>
+#endif
 
 #include <assert.h>
 #include <stdlib.h>

--- a/common/SFont.h
+++ b/common/SFont.h
@@ -36,7 +36,11 @@
 #ifndef SFONT_H
 #define SFONT_H
 
+#ifdef __APPLE__
+#include <SDL2/SDL.h>
+#else
 #include <SDL.h>
+#endif
 
 #ifdef __cplusplus 
 extern "C" {


### PR DESCRIPTION
This changeset fixes SDL includes in OSX so Xcode will find SDL headers in SDL2 framework.
